### PR TITLE
feat: 주간 회고록 자동 생성 기능 추가

### DIFF
--- a/scripts/generate_retrospective.py
+++ b/scripts/generate_retrospective.py
@@ -24,11 +24,16 @@ class JiraClient:
 
     def search_issues(self, jql: str, fields: list = None, max_results: int = 100) -> list:
         """JQL로 이슈 검색"""
-        url = f"{self.base_url}/rest/api/3/search"
+        # API v2 사용 (v3는 일부 환경에서 410 에러 발생)
+        url = f"{self.base_url}/rest/api/2/search"
+
+        # JQL에서 줄바꿈 제거 (URL 인코딩 문제 방지)
+        clean_jql = " ".join(jql.split())
+
         params = {
-            "jql": jql,
+            "jql": clean_jql,
             "maxResults": max_results,
-            "fields": fields or ["summary", "description", "status", "issuetype", "priority", "labels", "updated"]
+            "fields": ",".join(fields or ["summary", "description", "status", "issuetype", "priority", "labels", "updated"])
         }
 
         response = requests.get(url, auth=self.auth, headers=self.headers, params=params)

--- a/scripts/generate_retrospective.py
+++ b/scripts/generate_retrospective.py
@@ -25,7 +25,6 @@ class JiraClient:
             self.base_url = f"https://{base_url}"
         self.auth = (email, api_token)
         self.headers = {"Accept": "application/json"}
-        print(f"[DEBUG] Jira base URL: {self.base_url}")
 
     def search_issues(self, jql: str, fields: list = None, max_results: int = 100) -> list:
         """JQL로 이슈 검색"""
@@ -42,21 +41,9 @@ class JiraClient:
             "fields": ",".join(fields or ["summary", "description", "status", "issuetype", "priority", "labels", "updated"])
         }
 
-        # 디버그 로그
-        print(f"[DEBUG] Request URL: {url}")
-        print(f"[DEBUG] JQL: {clean_jql}")
-
         response = requests.get(url, auth=self.auth, headers=self.headers, params=params)
-
-        # 디버그: 응답 상태 및 내용
-        print(f"[DEBUG] Response status: {response.status_code}")
-        if response.status_code != 200:
-            print(f"[DEBUG] Response body: {response.text[:500]}")
-
         response.raise_for_status()
-        result = response.json()
-        print(f"[DEBUG] Total issues found: {result.get('total', 0)}")
-        return result.get("issues", [])
+        return response.json().get("issues", [])
 
 
 class RetrospectiveGenerator:

--- a/scripts/generate_retrospective.py
+++ b/scripts/generate_retrospective.py
@@ -24,16 +24,11 @@ class JiraClient:
 
     def search_issues(self, jql: str, fields: list = None, max_results: int = 100) -> list:
         """JQL로 이슈 검색"""
-        # API v2 사용 (v3는 일부 환경에서 410 에러 발생)
-        url = f"{self.base_url}/rest/api/2/search"
-
-        # JQL에서 줄바꿈 제거 (URL 인코딩 문제 방지)
-        clean_jql = " ".join(jql.split())
-
+        url = f"{self.base_url}/rest/api/3/search"
         params = {
-            "jql": clean_jql,
+            "jql": jql,
             "maxResults": max_results,
-            "fields": ",".join(fields or ["summary", "description", "status", "issuetype", "priority", "labels", "updated"])
+            "fields": fields or ["summary", "description", "status", "issuetype", "priority", "labels", "updated"]
         }
 
         response = requests.get(url, auth=self.auth, headers=self.headers, params=params)


### PR DESCRIPTION
## Summary
- 주간 회고록 자동 생성 GitHub Actions 워크플로우 추가
- Jira API를 통해 지난 7일간의 이슈를 조회하여 마크다운 회고록 생성
- 회고록 카테고리 및 기존 문서 추가

## Changes
- `scripts/generate_retrospective.py`: Jira 이슈 조회 및 회고록 생성 스크립트
- `.github/workflows/weekly-retrospective.yml`: 매주 금요일 자동 실행 워크플로우
- `_pages/Retrospective/`: 회고록 카테고리 및 기존 문서

## Test plan
- [x] 로컬에서 스크립트 실행 테스트
- [x] Jira API 이슈 조회 확인 (12개 이슈 정상 조회)
- [x] GitHub Actions 수동 실행 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)